### PR TITLE
Include <algorithm> from standard c++ library

### DIFF
--- a/diff_match_patch.h
+++ b/diff_match_patch.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <cstdlib>
 #include <cwchar>
 #include <time.h>


### PR DESCRIPTION
std::max()" is not found on some configurations.

See robotology/yarp#134
