### PR TITLE
Add missing Subversion changes.

### DIFF
--- a/diff_match_patch_test_string.cpp
+++ b/diff_match_patch_test_string.cpp
@@ -362,7 +362,11 @@ class diff_match_patch_test : diff_match_patch<string> {
     diffs = diffList(Diff(EQUAL, "xa"), Diff(DELETE, "a"), Diff(EQUAL, "a"));
     dmp.diff_cleanupSemanticLossless(diffs);
     assertEquals("diff_cleanupSemantic: Hitting the end.", diffList(Diff(EQUAL, "xaa"), Diff(DELETE, "a")), diffs);
-  }
+
+    diffs = diffList(Diff(EQUAL, "The xxx. The "), Diff(INSERT, "zzz. The "), Diff(EQUAL, "yyy."));
+    dmp.diff_cleanupSemanticLossless(diffs);
+    assertEquals("diff_cleanupSemantic: Sentence boundaries.", diffList(Diff(EQUAL, "The xxx."), Diff(INSERT, " The zzz."), Diff(EQUAL, " The yyy.")), diffs);
+}
 
   void testDiffCleanupSemantic() {
     // Cleanup semantically trivial equalities.

--- a/diff_match_patch_test_string.cpp
+++ b/diff_match_patch_test_string.cpp
@@ -392,11 +392,15 @@ class diff_match_patch_test : diff_match_patch<string> {
 
     diffs = diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef"));
     dmp.diff_cleanupSemantic(diffs);
-    assertEquals("diff_cleanupSemantic: Overlap elimination #1.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xx"), Diff(INSERT, "def")), diffs);
+    assertEquals("diff_cleanupSemantic: No overlap elimination.", diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef")), diffs);
 
-    diffs = diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef"), Diff(DELETE, "ABCXX"), Diff(INSERT, "XXDEF"));
+    diffs = diffList(Diff(DELETE, "abcxxx"), Diff(INSERT, "xxxdef"));
     dmp.diff_cleanupSemantic(diffs);
-    assertEquals("diff_cleanupSemantic: Overlap elimination #2.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xx"), Diff(INSERT, "def"), Diff(DELETE, "ABC"), Diff(EQUAL, "XX"), Diff(INSERT, "DEF")), diffs);
+    assertEquals("diff_cleanupSemantic: Overlap elimination.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xxx"), Diff(INSERT, "def")), diffs);
+
+    diffs = diffList(Diff(DELETE, "abcd1212"), Diff(INSERT, "1212efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A3"), Diff(INSERT, "3BC"));
+    dmp.diff_cleanupSemantic(diffs);
+    assertEquals("diff_cleanupSemantic: Two overlap eliminations.", diffList(Diff(DELETE, "abcd"), Diff(EQUAL, "1212"), Diff(INSERT, "efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A"), Diff(EQUAL, "3"), Diff(INSERT, "BC")), diffs);
   }
 
   void testDiffCleanupEfficiency() {

--- a/diff_match_patch_test_string.cpp
+++ b/diff_match_patch_test_string.cpp
@@ -148,7 +148,11 @@ class diff_match_patch_test : diff_match_patch<string> {
     assertEquals("diff_commonOverlap: No overlap.", 0, dmp.diff_commonOverlap("123456", "abcd"));
 
     assertEquals("diff_commonOverlap: Overlap.", 3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
-  }
+
+    // Some overly clever languages (C#) may treat ligatures as equal to their
+    // component letters.  E.g. U+FB01 == 'fi'
+    assertEquals("diff_commonOverlap: Unicode.", 0, dmp.diff_commonOverlap("fi", "\xEF\xAC\x81i"));
+}
 
   void testDiffHalfmatch() {
     // Detect a halfmatch.

--- a/diff_match_patch_test_string.cpp
+++ b/diff_match_patch_test_string.cpp
@@ -402,6 +402,10 @@ class diff_match_patch_test : diff_match_patch<string> {
     dmp.diff_cleanupSemantic(diffs);
     assertEquals("diff_cleanupSemantic: Overlap elimination.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xxx"), Diff(INSERT, "def")), diffs);
 
+    diffs = diffList(Diff(DELETE, "xxxabc"), Diff(INSERT, "defxxx"));
+    dmp.diff_cleanupSemantic(diffs);
+    assertEquals("diff_cleanupSemantic: Reverse overlap elimination.", diffList(Diff(INSERT, "def"), Diff(EQUAL, "xxx"), Diff(DELETE, "abc")), diffs);
+
     diffs = diffList(Diff(DELETE, "abcd1212"), Diff(INSERT, "1212efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A3"), Diff(INSERT, "3BC"));
     dmp.diff_cleanupSemantic(diffs);
     assertEquals("diff_cleanupSemantic: Two overlap eliminations.", diffList(Diff(DELETE, "abcd"), Diff(EQUAL, "1212"), Diff(INSERT, "efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A"), Diff(EQUAL, "3"), Diff(INSERT, "BC")), diffs);

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -148,7 +148,11 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     assertEquals("diff_commonOverlap: No overlap.", 0, dmp.diff_commonOverlap("123456", "abcd"));
 
     assertEquals("diff_commonOverlap: Overlap.", 3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
-  }
+
+    // Some overly clever languages (C#) may treat ligatures as equal to their
+    // component letters.  E.g. U+FB01 == 'fi'
+    assertEquals("diff_commonOverlap: Unicode.", 0, dmp.diff_commonOverlap("fi", L"\ufb01i"));
+}
 
   void testDiffHalfmatch() {
     // Detect a halfmatch.

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -362,7 +362,11 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     diffs = diffList(Diff(EQUAL, "xa"), Diff(DELETE, "a"), Diff(EQUAL, "a"));
     dmp.diff_cleanupSemanticLossless(diffs);
     assertEquals("diff_cleanupSemantic: Hitting the end.", diffList(Diff(EQUAL, "xaa"), Diff(DELETE, "a")), diffs);
-  }
+
+    diffs = diffList(Diff(EQUAL, "The xxx. The "), Diff(INSERT, "zzz. The "), Diff(EQUAL, "yyy."));
+    dmp.diff_cleanupSemanticLossless(diffs);
+    assertEquals("diff_cleanupSemantic: Sentence boundaries.", diffList(Diff(EQUAL, "The xxx."), Diff(INSERT, " The zzz."), Diff(EQUAL, " The yyy.")), diffs);
+}
 
   void testDiffCleanupSemantic() {
     // Cleanup semantically trivial equalities.

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -392,11 +392,15 @@ class diff_match_patch_test : diff_match_patch<wastring> {
 
     diffs = diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef"));
     dmp.diff_cleanupSemantic(diffs);
-    assertEquals("diff_cleanupSemantic: Overlap elimination #1.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xx"), Diff(INSERT, "def")), diffs);
+    assertEquals("diff_cleanupSemantic: No overlap elimination.", diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef")), diffs);
 
-    diffs = diffList(Diff(DELETE, "abcxx"), Diff(INSERT, "xxdef"), Diff(DELETE, "ABCXX"), Diff(INSERT, "XXDEF"));
+    diffs = diffList(Diff(DELETE, "abcxxx"), Diff(INSERT, "xxxdef"));
     dmp.diff_cleanupSemantic(diffs);
-    assertEquals("diff_cleanupSemantic: Overlap elimination #2.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xx"), Diff(INSERT, "def"), Diff(DELETE, "ABC"), Diff(EQUAL, "XX"), Diff(INSERT, "DEF")), diffs);
+    assertEquals("diff_cleanupSemantic: Overlap elimination.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xxx"), Diff(INSERT, "def")), diffs);
+
+    diffs = diffList(Diff(DELETE, "abcd1212"), Diff(INSERT, "1212efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A3"), Diff(INSERT, "3BC"));
+    dmp.diff_cleanupSemantic(diffs);
+    assertEquals("diff_cleanupSemantic: Two overlap eliminations.", diffList(Diff(DELETE, "abcd"), Diff(EQUAL, "1212"), Diff(INSERT, "efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A"), Diff(EQUAL, "3"), Diff(INSERT, "BC")), diffs);
   }
 
   void testDiffCleanupEfficiency() {

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -402,6 +402,10 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     dmp.diff_cleanupSemantic(diffs);
     assertEquals("diff_cleanupSemantic: Overlap elimination.", diffList(Diff(DELETE, "abc"), Diff(EQUAL, "xxx"), Diff(INSERT, "def")), diffs);
 
+    diffs = diffList(Diff(DELETE, "xxxabc"), Diff(INSERT, "defxxx"));
+    dmp.diff_cleanupSemantic(diffs);
+    assertEquals("diff_cleanupSemantic: Reverse overlap elimination.", diffList(Diff(INSERT, "def"), Diff(EQUAL, "xxx"), Diff(DELETE, "abc")), diffs);
+
     diffs = diffList(Diff(DELETE, "abcd1212"), Diff(INSERT, "1212efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A3"), Diff(INSERT, "3BC"));
     dmp.diff_cleanupSemantic(diffs);
     assertEquals("diff_cleanupSemantic: Two overlap eliminations.", diffList(Diff(DELETE, "abcd"), Diff(EQUAL, "1212"), Diff(INSERT, "efghi"), Diff(EQUAL, "----"), Diff(DELETE, "A"), Diff(EQUAL, "3"), Diff(INSERT, "BC")), diffs);


### PR DESCRIPTION
The STL version of diff_match_patch was forked around revision 85 of the Subversion code (https://code.google.com/p/google-diff-match-patch/source/list). The bugfixes applied to the upstream version haven't been ported to the STL-based version, meaning that it has known bugs that produce incorrect output for certain inputs.

This PR ports the missing Subversion C++ changes to the STL version of the code.