### PR TITLE
Fix "line mode" diff algorithm

### DIFF
--- a/diff_match_patch.h
+++ b/diff_match_patch.h
@@ -141,7 +141,7 @@ class diff_match_patch {
         case DELETE:
           return traits::cs(L"DELETE");
         case EQUAL:
-          return traits::cs(L"EQUAtraits::cs(L");
+          return traits::cs(L"EQUAL");
       }
       throw string_t(traits::cs(L"Invalid operation."));
     }

--- a/diff_match_patch.h
+++ b/diff_match_patch.h
@@ -294,6 +294,8 @@ class diff_match_patch {
    * @param Linked List of Diff objects.
    */
  private:
+  template<typename string2, typename traits2> friend class diff_match_patch;
+
   static void diff_main(const string_t &text1, const string_t &text2, bool checklines, clock_t deadline, Diffs& diffs) {
     diffs.clear();
 
@@ -419,10 +421,12 @@ class diff_match_patch {
     Lines linearray;
     diff_linesToChars(text1, text2, linearray);
 
-    diff_main(text1, text2, false, deadline, diffs);
+    diff_match_patch<std::basic_string<size_t> > line_diff_match_patch;
+    diff_match_patch<std::basic_string<size_t> >::Diffs line_diffs;
+    line_diff_match_patch.diff_main(linearray.text1, linearray.text2, false, deadline, line_diffs);
 
     // Convert the diff back to original text.
-    diff_charsToLines(diffs, linearray);
+    diffs = diff_charsToLines(line_diffs, linearray);
     // Eliminate freak matches (e.g. blank lines)
     diff_cleanupSemantic(diffs);
 
@@ -630,19 +634,18 @@ class diff_match_patch {
     bool operator<(const LinePtr& p) const
       { return this->second < p.second? true : this->second > p.second? false : string_t::traits_type::compare(this->first, p.first, this->second) < 0; }
   };
-  struct Lines : std::vector<LinePtr> { string_t text1, text2; };
+  struct Lines : std::vector<LinePtr> { std::basic_string<size_t> text1, text2; };
 
-  static void diff_linesToChars(string_t &text1, string_t &text2, Lines& lineArray) {
+  static void diff_linesToChars(const string_t &text1, const string_t &text2, Lines& lineArray) {
     std::map<LinePtr, size_t> lineHash;
-    lineArray.text1.swap(text1), lineArray.text2.swap(text2);
     // e.g. linearray[4] == "Hello\n"
     // e.g. linehash.get("Hello\n") == 4
 
     // "\x00" is a valid character, but various debuggers don't like it.
     // So we'll insert a junk entry to avoid generating a null character.
 
-    text1 = diff_linesToCharsMunge(lineArray.text1, lineHash);
-    text2 = diff_linesToCharsMunge(lineArray.text2, lineHash);
+    lineArray.text1 = diff_linesToCharsMunge(text1, lineHash);
+    lineArray.text2 = diff_linesToCharsMunge(text2, lineHash);
 
     lineArray.resize(lineHash.size() + 1);
     for (typename std::map<LinePtr, size_t>::const_iterator i = lineHash.begin(); i != lineHash.end(); ++i)
@@ -657,8 +660,8 @@ class diff_match_patch {
    * @return Encoded string.
    */
  private:
-  static string_t diff_linesToCharsMunge(const string_t &text, std::map<LinePtr, size_t> &lineHash) {
-    string_t chars;
+  static std::basic_string<size_t> diff_linesToCharsMunge(const string_t &text, std::map<LinePtr, size_t> &lineHash) {
+    std::basic_string<size_t> chars;
     // Walk the text, pulling out a substring for each line.
     // text.split('\n') would would temporarily double our memory footprint.
     // Modifying text would create many large strings to garbage collect.
@@ -666,7 +669,7 @@ class diff_match_patch {
     for (typename string_t::const_pointer lineStart = text.c_str(), textEnd = lineStart + text.size(); lineStart < textEnd; lineStart += lineLen + 1) {
       lineLen = next_token(text, traits::from_wchar(L'\n'), lineStart);
       if (lineStart + lineLen == textEnd) --lineLen;
-      chars += (char_t)(*lineHash.insert(std::make_pair(LinePtr(lineStart, lineLen + 1), lineHash.size() + 1)).first).second;
+      chars.push_back((*lineHash.insert(std::make_pair(LinePtr(lineStart, lineLen + 1), lineHash.size() + 1)).first).second);
     }
     return chars;
   }
@@ -678,15 +681,17 @@ class diff_match_patch {
    * @param lineArray List of pointers to unique strings.
    */
  private:
-  static void diff_charsToLines(Diffs &diffs, const Lines& lineArray) {
-    for (typename Diffs::iterator cur_diff = diffs.begin(); cur_diff != diffs.end(); ++cur_diff) {
+  static Diffs diff_charsToLines(const typename diff_match_patch<std::basic_string<size_t> >::Diffs &line_diffs, const Lines& lineArray) {
+    Diffs diffs;
+    for (typename diff_match_patch<std::basic_string<size_t> >::Diffs::const_iterator cur_diff = line_diffs.begin(); cur_diff != line_diffs.end(); ++cur_diff) {
       string_t text;
-      for (int y = 0; y < (int)(*cur_diff).text.length(); y++) {
-        const LinePtr& lp = lineArray[static_cast<size_t>((*cur_diff).text[y])];
+      for (size_t y = 0; y < cur_diff->text.length(); y++) {
+        const LinePtr& lp = lineArray[cur_diff->text[y]];
         text.append(lp.first, lp.second);
       }
-      (*cur_diff).text.swap(text);
+      diffs.push_back(Diff(static_cast<Operation>(cur_diff->operation), text));
     }
+    return diffs;
   }
 
   /**
@@ -2589,5 +2594,16 @@ template <> struct diff_match_patch_traits<char> : diff_match_patch_utf32_direct
   static const char tab = '\t';
 };
 
+template <> struct diff_match_patch_traits<size_t> : diff_match_patch_utf32_direct<size_t> {
+  static bool is_alnum(size_t c) { return false; }
+  static bool is_digit(size_t c) { return false; }
+  static bool is_space(size_t c) { return false; }
+  static int to_int(const char* s) { return 0; }
+  static size_t from_wchar(wchar_t c) { return static_cast<size_t>(c); }
+  static wchar_t to_wchar(size_t c) { return static_cast<wchar_t>(c); }
+  static std::basic_string<size_t> cs(const wchar_t* s) { return std::basic_string<size_t>(s, s + wcslen(s)); }
+  static const size_t eol = '\n';
+  static const size_t tab = '\t';
+};
 
 #endif // DIFF_MATCH_PATCH_H

--- a/diff_match_patch_test_string.cpp
+++ b/diff_match_patch_test_string.cpp
@@ -85,7 +85,7 @@ class diff_match_patch_test : diff_match_patch<string> {
       testDiffCommonOverlap();
       testDiffHalfmatch();
       testDiffLinesToChars();
-      //TODO testDiffCharsToLines();
+      testDiffCharsToLines();
       testDiffCleanupMerge();
       testDiffCleanupSemanticLossless();
       testDiffCleanupSemantic();
@@ -275,8 +275,8 @@ class diff_match_patch_test : diff_match_patch<string> {
       tmpVector[x].second -= prev;
       prev += tmpVector[x].second;
     }
-    assertEquals("diff_linesToChars: More than 256 (setup).", n + 1, tmpVector.size());
-    assertEquals("diff_linesToChars: More than 256 (setup).", n, chars.length());
+    assertEquals("diff_charsToLines: More than 256 (setup).", n + 1, tmpVector.size());
+    assertEquals("diff_charsToLines: More than 256 (setup).", n, chars.length());
     diffs = diffList(Diff(DELETE, chars));
     dmp.diff_charsToLines(diffs, tmpVector);
     assertEquals("diff_charsToLines: More than 256.", diffList(Diff(DELETE, tmpVector.text1)), diffs);

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -67,6 +67,13 @@ ostream& operator<<(ostream& o, const wastring& s)
   return o;
 }
 
+std::basic_string<size_t> make_size_t_string(const char * s)
+{
+  std::basic_string<size_t> str;
+  for (const char * c = s; *c != 0; c++)
+    str.push_back(*c);
+  return str;
+}
 
 #define dmp (*this)
 
@@ -185,58 +192,60 @@ class diff_match_patch_test : diff_match_patch<wastring> {
   void testDiffLinesToChars() {
     // Convert lines down to characters.
     Lines tmpVector, resVector;
-    tmpVector.text1 = string_t("alpha\n");
-    tmpVector.text2 = string_t("beta\n");
-    tmpVector.resize(3);
-    tmpVector[1] = LinePtr(tmpVector.text1.c_str(), tmpVector.text1.length());
-    tmpVector[2] = LinePtr(tmpVector.text2.c_str(), tmpVector.text2.length());
     string_t text1("alpha\nbeta\nalpha\n"), text2("beta\nalpha\nbeta\n");
-    dmp.diff_linesToChars(text1, text2, resVector);
-    assertEquals("diff_linesToChars:", "\1\2\1", "\2\1\2", tmpVector, text1, text2, resVector);
-
-    tmpVector.text1 = string_t("alpha\r\n");
-    tmpVector.text2 = string_t("beta\r\n\r\n");
-    tmpVector.resize(4);
-    tmpVector[1] = LinePtr(tmpVector.text1.c_str(), tmpVector.text1.length());
-    tmpVector[2] = LinePtr(tmpVector.text2.c_str(), tmpVector.text2.length() - 2);
-    tmpVector[3] = LinePtr(tmpVector.text2.c_str() + 6, 2);
-    text1.clear(), text2 = "alpha\r\nbeta\r\n\r\n\r\n";
-    dmp.diff_linesToChars(text1, text2, resVector);
-    assertEquals("diff_linesToChars:", string_t(), "\1\2\3\3", tmpVector, text1, text2, resVector);
-
-    tmpVector.text1 = string_t("a");
-    tmpVector.text2 = string_t("b");
+    tmpVector.text1 = make_size_t_string("\1\2\1");
+    tmpVector.text2 = make_size_t_string("\2\1\2");
     tmpVector.resize(3);
-    tmpVector[1] = LinePtr(tmpVector.text1.c_str(), tmpVector.text1.length());
-    tmpVector[2] = LinePtr(tmpVector.text2.c_str(), tmpVector.text2.length());
-    text1 = "a", text2 = "b";
+    tmpVector[1] = LinePtr(text1.c_str(), 6);
+    tmpVector[2] = LinePtr(text1.c_str() + 6, 5);
+    dmp.diff_linesToChars(text1, text2, resVector);
+    assertEquals("diff_linesToChars:", tmpVector, resVector);
+
+    text1.clear(), text2 = "alpha\r\nbeta\r\n\r\n\r\n";
+    tmpVector.text1.clear();
+    tmpVector.text2 = make_size_t_string("\1\2\3\3");
+    tmpVector.resize(4);
+    tmpVector[1] = LinePtr(text2.c_str(), 7);
+    tmpVector[2] = LinePtr(text2.c_str() + 7, 6);
+    tmpVector[3] = LinePtr(text2.c_str() + 13, 2);
     resVector.clear();
     dmp.diff_linesToChars(text1, text2, resVector);
-    assertEquals("diff_linesToChars:", "\1", "\2", tmpVector, text1, text2, resVector);
+    assertEquals("diff_linesToChars:", tmpVector, resVector);
+
+    text1 = "a", text2 = "b";
+    tmpVector.text1 = make_size_t_string("\1");
+    tmpVector.text2 = make_size_t_string("\2");
+    tmpVector.resize(3);
+    tmpVector[1] = LinePtr(text1.c_str(), text1.length());
+    tmpVector[2] = LinePtr(text2.c_str(), text2.length());
+    resVector.clear();
+    dmp.diff_linesToChars(text1, text2, resVector);
+    assertEquals("diff_linesToChars:", tmpVector, resVector);
 
     // More than 65536 to reveal any 16-bit limitations.
     size_t n = 70000;
     tmpVector.resize(n + 1);
     tmpVector[0].second = 0;
     basic_stringstream<char_t> lines;
-    string_t chars;
+    tmpVector.text1.clear();
     for (size_t x = 1; x < n + 1; x++) {
       lines << x << traits::eol;
-      tmpVector[x].second = lines.str().size();
-      chars += (wchar_t)x;
+      tmpVector[x].second = lines.tellp();
+      tmpVector.text1.push_back(x);
     }
-    tmpVector.text1 = lines.str();
+    text1 = lines.str();
     for (size_t x = 1, prev = 0; x < n + 1; x++) {
-      tmpVector[x].first = tmpVector.text1.c_str() + prev;
+      tmpVector[x].first = text1.c_str() + prev;
       tmpVector[x].second -= prev;
       prev += tmpVector[x].second;
     }
     assertEquals("diff_linesToChars: More than 65536 (setup).", n + 1, tmpVector.size());
-    assertEquals("diff_linesToChars: More than 65536 (setup).", n, chars.length());
-    text1 = tmpVector.text1, text2.clear();
+    assertEquals("diff_linesToChars: More than 65536 (setup).", n, tmpVector.text1.length());
+    tmpVector.text2.clear();
+    text2.clear();
     resVector.clear();
     dmp.diff_linesToChars(text1, text2, resVector);
-    assertEquals("diff_linesToChars:", chars, "", tmpVector, text1, text2, resVector);
+    assertEquals("diff_linesToChars:", tmpVector, resVector);
   }
 
   void testDiffCharsToLines() {
@@ -246,16 +255,16 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     assertEquals("diff_charsToLines:", Diff(EQUAL, "a"), Diff(EQUAL, "a"));
 
     // Convert chars up to lines.
-    Diffs diffs;
-    diffs.push_back(Diff(EQUAL, "\1\2\1"));  // ("\u0001\u0002\u0001");
-    diffs.push_back(Diff(INSERT, "\2\1\2"));  // ("\u0002\u0001\u0002");
+    typedef diff_match_patch<std::basic_string<size_t> > line_dmp; 
+    line_dmp::Diffs line_diffs;
+    line_diffs.push_back(line_dmp::Diff(line_dmp::EQUAL, make_size_t_string("\1\2\1")));
+    line_diffs.push_back(line_dmp::Diff(line_dmp::INSERT, make_size_t_string("\2\1\2")));
+    string_t text1("alpha\n"), text2("beta\n");
     Lines tmpVector;
-    tmpVector.text1 = string_t("alpha\n");
-    tmpVector.text2 = string_t("beta\n");
     tmpVector.resize(3);
-    tmpVector[1] = LinePtr(tmpVector.text1.c_str(), tmpVector.text1.length());
-    tmpVector[2] = LinePtr(tmpVector.text2.c_str(), tmpVector.text2.length());
-    dmp.diff_charsToLines(diffs, tmpVector);
+    tmpVector[1] = LinePtr(text1.c_str(), text1.length());
+    tmpVector[2] = LinePtr(text2.c_str(), text2.length());
+    Diffs diffs = dmp.diff_charsToLines(line_diffs, tmpVector);
     assertEquals("diff_charsToLines:", diffList(Diff(EQUAL, "alpha\nbeta\nalpha\n"), Diff(INSERT, "beta\nalpha\nbeta\n")), diffs);
 
     // More than 65536 to reveal any 16-bit limitations.
@@ -263,23 +272,24 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     tmpVector.resize(n + 1);
     tmpVector[0].second = 0;
     basic_stringstream<char_t> lines;
-    string_t chars;
+    tmpVector.text1.clear();
     for (size_t x = 1; x < n + 1; x++) {
       lines << x << traits::eol;
-      tmpVector[x].second = lines.str().size();
-      chars += (char_t)x;
-    }
-    tmpVector.text1 = lines.str();
+      tmpVector[x].second = lines.tellp();
+      tmpVector.text1.push_back(x);
+   }
+    text1 = lines.str();
     for (size_t x = 1, prev = 0; x < n + 1; x++) {
-      tmpVector[x].first = tmpVector.text1.c_str() + prev;
+      tmpVector[x].first = text1.c_str() + prev;
       tmpVector[x].second -= prev;
       prev += tmpVector[x].second;
     }
     assertEquals("diff_charsToLines: More than 65536 (setup).", n + 1, tmpVector.size());
-    assertEquals("diff_charsToLines: More than 65536 (setup).", n, chars.length());
-    diffs = diffList(Diff(DELETE, chars));
-    dmp.diff_charsToLines(diffs, tmpVector);
-    assertEquals("diff_charsToLines: More than 65536.", diffList(Diff(DELETE, tmpVector.text1)), diffs);
+    assertEquals("diff_charsToLines: More than 65536 (setup).", n, tmpVector.text1.length());
+    line_diffs.clear();
+    line_diffs.push_back(line_dmp::Diff(line_dmp::DELETE, tmpVector.text1));
+    diffs = dmp.diff_charsToLines(line_diffs, tmpVector);
+    assertEquals("diff_charsToLines: More than 65536.", diffList(Diff(DELETE, text1)), diffs);
   }
 
   void testDiffCleanupMerge() {
@@ -1026,11 +1036,10 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     cout << strCase << " OK" << endl;
   }
 
-  void assertEquals(const char* strCase, const string_t& text1_1, const string_t& text2_1, const Lines &lines1,
-                                                                const string_t& text1_2, const string_t& text2_2, const Lines &lines2)
+  void assertEquals(const char* strCase, const Lines &lines1, const Lines &lines2)
   {
     bool fail = false;
-    if (text1_1 != text1_2 || text2_1 != text2_2 || lines1.size() != lines2.size())
+    if (lines1.text1 != lines2.text1 || lines1.text2 != lines2.text2 || lines1.size() != lines2.size())
       fail = true;
     else
       for (Lines::const_iterator i = lines1.begin(), j = lines2.begin(); i != lines1.end(); ++i, ++j)
@@ -1038,7 +1047,7 @@ class diff_match_patch_test : diff_match_patch<wastring> {
 
     if (fail) {
       // Build human readable description of both lists.
-      string_t listString1 = "\"" + text1_1 + "\", \"" + text2_1 + "\", (\"";
+      string_t listString1 = "(\"";
       bool first = true;
       for (Lines::const_iterator i = lines1.begin() + 1; i != lines1.end(); ++i) {
         if (!first) listString1 += "\", \"";
@@ -1046,7 +1055,7 @@ class diff_match_patch_test : diff_match_patch<wastring> {
         first = false;
       }
       listString1 += "\")";
-      string_t listString2 = "\"" + text1_2 + "\", \"" + text2_2 + "\", (\"";
+      string_t listString2 = "(\"";
       first = true;
       for (Lines::const_iterator j = lines2.begin() + 1; j != lines2.end(); ++j) {
         if (!first) listString2 += "\", \"";

--- a/diff_match_patch_test_wstring.cpp
+++ b/diff_match_patch_test_wstring.cpp
@@ -214,8 +214,8 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     dmp.diff_linesToChars(text1, text2, resVector);
     assertEquals("diff_linesToChars:", "\1", "\2", tmpVector, text1, text2, resVector);
 
-    // More than 256 to reveal any 8-bit limitations.
-    size_t n = 300;
+    // More than 65536 to reveal any 16-bit limitations.
+    size_t n = 70000;
     tmpVector.resize(n + 1);
     tmpVector[0].second = 0;
     basic_stringstream<char_t> lines;
@@ -231,8 +231,8 @@ class diff_match_patch_test : diff_match_patch<wastring> {
       tmpVector[x].second -= prev;
       prev += tmpVector[x].second;
     }
-    assertEquals("diff_linesToChars: More than 256 (setup).", n + 1, tmpVector.size());
-    assertEquals("diff_linesToChars: More than 256 (setup).", n, chars.length());
+    assertEquals("diff_linesToChars: More than 65536 (setup).", n + 1, tmpVector.size());
+    assertEquals("diff_linesToChars: More than 65536 (setup).", n, chars.length());
     text1 = tmpVector.text1, text2.clear();
     resVector.clear();
     dmp.diff_linesToChars(text1, text2, resVector);
@@ -258,8 +258,8 @@ class diff_match_patch_test : diff_match_patch<wastring> {
     dmp.diff_charsToLines(diffs, tmpVector);
     assertEquals("diff_charsToLines:", diffList(Diff(EQUAL, "alpha\nbeta\nalpha\n"), Diff(INSERT, "beta\nalpha\nbeta\n")), diffs);
 
-    // More than 256 to reveal any 8-bit limitations.
-    size_t n = 300;
+    // More than 65536 to reveal any 16-bit limitations.
+    size_t n = 70000;
     tmpVector.resize(n + 1);
     tmpVector[0].second = 0;
     basic_stringstream<char_t> lines;
@@ -275,11 +275,11 @@ class diff_match_patch_test : diff_match_patch<wastring> {
       tmpVector[x].second -= prev;
       prev += tmpVector[x].second;
     }
-    assertEquals("diff_linesToChars: More than 256 (setup).", n + 1, tmpVector.size());
-    assertEquals("diff_linesToChars: More than 256 (setup).", n, chars.length());
+    assertEquals("diff_charsToLines: More than 65536 (setup).", n + 1, tmpVector.size());
+    assertEquals("diff_charsToLines: More than 65536 (setup).", n, chars.length());
     diffs = diffList(Diff(DELETE, chars));
     dmp.diff_charsToLines(diffs, tmpVector);
-    assertEquals("diff_charsToLines: More than 256.", diffList(Diff(DELETE, tmpVector.text1)), diffs);
+    assertEquals("diff_charsToLines: More than 65536.", diffList(Diff(DELETE, tmpVector.text1)), diffs);
   }
 
   void testDiffCleanupMerge() {


### PR DESCRIPTION
In a "line mode" diff, the code hashed each input line to a unique character before performing the diff. However, the range of the hash output was restricted to the character set of the input strings (256 values for `char`; 65,536 for 16-bit `wchar_t`), causing a diff failure when the input size exceeded that many lines.

`diff_lineMode` now hashes each input line to a `size_t` value, which is sufficient to accommodate any string that can fit in memory.