### PR TITLE
Fix search-and-replace error.

### DIFF
--- a/diff_match_patch.h
+++ b/diff_match_patch.h
@@ -141,7 +141,7 @@ class diff_match_patch {
         case DELETE:
           return traits::cs(L"DELETE");
         case EQUAL:
-          return traits::cs(L"EQUAtraits::cs(L");
+          return traits::cs(L"EQUAL");
       }
       throw string_t(traits::cs(L"Invalid operation."));
     }


### PR DESCRIPTION
It appears that `L"` was globally replaced with `traits::cs(L"` at some point. This introduced an error in a literal string.