### PR TITLE
Fix bug in diff_commonOverlap.

### DIFF
--- a/diff_match_patch.h
+++ b/diff_match_patch.h
@@ -769,7 +769,7 @@ class diff_match_patch {
         return best;
       }
       length += found;
-      if (found == 0 || right(text1_trunc, length) == right(text2_trunc, length)) {
+      if (found == 0 || right(text1_trunc, length) == text2_trunc.substr(0, length)) {
         best = length;
         length++;
       }


### PR DESCRIPTION
This was an error introduced in the STL port. Compare to [line 634 in the original Qt source](https://code.google.com/p/google-diff-match-patch/source/browse/trunk/cpp/diff_match_patch.cpp#634), which has `text1_trunc.right(length) == text2_trunc.left(length)`.

