### PR TITLE
Rename enum values to avoid conflict with windows.h DELETE macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ diff_match_patch_test
 diff_match_patch_test_utf8
 CMakeLists.txt.user
 speedtest
+build
+.cache


### PR DESCRIPTION
- Renamed `DELETE` to `OP_DELETE` in the `Operation` enum to avoid conflict with the DELETE macro defined in windows.h.
- Updated all references to the enum values to use the new names (e.g., `OP_DELETE`, `OP_INSERT`, `OP_EQUAL`).
- Ensured compatibility with existing code by making necessary adjustments where the enum was used.
#21 